### PR TITLE
Fix for files with multiple periods

### DIFF
--- a/lib/open-unsupported-files.coffee
+++ b/lib/open-unsupported-files.coffee
@@ -5,7 +5,7 @@ module.exports =
     extensions:
       title: 'extensions'
       type: 'string'
-      default: 'doc,xls,ppt,docx,xlsx,pptx,pdf,rtf,zip,7z,rar,tar,tar.gz,tar.bz2'
+      default: 'doc,xls,ppt,docx,xlsx,pptx,pdf,rtf,zip,7z,rar,tar,gz,bz2'
 
   activate: ->
     @extensions = atom.config.get('open-unsupported-files.extensions')?.split(',')

--- a/lib/open-unsupported-files.coffee
+++ b/lib/open-unsupported-files.coffee
@@ -5,7 +5,7 @@ module.exports =
     extensions:
       title: 'extensions'
       type: 'string'
-      default: 'doc,xls,ppt,docx,xlsx,pptx,pdf,rtf,zip,7z,rar,tar,gz,bz2'
+      default: 'doc,docx,xls,pdf,exe,bat'
 
   activate: ->
     @extensions = atom.config.get('open-unsupported-files.extensions')?.split(',')

--- a/lib/open-unsupported-files.coffee
+++ b/lib/open-unsupported-files.coffee
@@ -5,7 +5,7 @@ module.exports =
     extensions:
       title: 'extensions'
       type: 'string'
-      default: 'doc,docx,xls,pdf,exe,bat'
+      default: 'doc,docx,xls,pdf'
 
   activate: ->
     @extensions = atom.config.get('open-unsupported-files.extensions')?.split(',')

--- a/lib/open-unsupported-files.coffee
+++ b/lib/open-unsupported-files.coffee
@@ -18,7 +18,7 @@ module.exports =
           filepath = entry.file.path
           return @originalEntryClicked.call(tv,e) unless filepath
           filename = entry.file.name
-          if filename?.substring(filename.indexOf('.') + 1 ).toLowerCase() in @extensions
+          if filename?.substring(filename.lastIndexOf('.') + 1 ).toLowerCase() in @extensions
             shell.openItem(filepath)
             return false
           else

--- a/lib/open-unsupported-files.coffee
+++ b/lib/open-unsupported-files.coffee
@@ -5,7 +5,7 @@ module.exports =
     extensions:
       title: 'extensions'
       type: 'string'
-      default: 'doc,docx,xls,pdf'
+      default: 'doc,xls,ppt,docx,xlsx,pptx,pdf,rtf,zip,7z,rar,tar,tar.gz,tar.bz2'
 
   activate: ->
     @extensions = atom.config.get('open-unsupported-files.extensions')?.split(',')


### PR DESCRIPTION
I noticed when I tried to open a file with multiple periods it wasn't detected. Here's the fix.

Also if you don't mind I updated the default extension list.
