### PR TITLE
Replace removed shell API method

### DIFF
--- a/lib/open-unsupported-files.coffee
+++ b/lib/open-unsupported-files.coffee
@@ -17,8 +17,8 @@ module.exports =
 
           if extension in @extensions
             if e.detail is 2
-              shell = require('shell')
-              shell.openItem(path)
+              {shell} = require('electron')
+              shell.openPath(path)
             return false
           else
             @originalFileViewEntryClicked.call(tv, e)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "atom": ">=1.56.0 <2.0.0"
   },
   "dependencies": {
-    "atom-utils": ">=0.6.3",
-    "shell": "^0.3.2"
+    "atom-utils": ">=0.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/skandasoft/open-unsupported-files",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.56.0 <2.0.0"
   },
   "dependencies": {
     "atom-utils": ">=0.6.3",


### PR DESCRIPTION
The `shell.openItem()` method has been replaced in Electron 9, which the latest Atom v1.56 depends on. Since the upgrade from Electron 6 to 9 was a substantial one, package developers never got a deprecation warning and now have to act fast to keep their packages working. This PR uses the new API method and bumps the minimum Atom version to accordingly.